### PR TITLE
Fix: Critical typo in index.js module export

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = requires('./lib/btree');
+module.exports = require('./lib/btree');


### PR DESCRIPTION
## Description
Fixes critical typo in index.js that prevents the module from loading.

## Changes
- Changed `requires` to `require` in index.js
- This was causing a ReferenceError when trying to load the module

## Testing
- Module now loads without errors
- Basic functionality verified

## Impact
- **Critical**: Module was completely broken before this fix
- No breaking changes
- Immediate improvement to module usability