### PR TITLE
Fix: Remove function root reference update

### DIFF
--- a/lib/btree.js
+++ b/lib/btree.js
@@ -267,33 +267,33 @@
 
 	var remove = function(node, key) {
 		if (!node) {
-			return;
+			return null;
 		}
 
 		if (key < node.key) {
-			remove(node.left, key);
+			node.left = remove(node.left, key);
 		} else if (key > node.key) {
-			remove(node.right, key);
+			node.right = remove(node.right, key);
 		} else {
-			if (node.left && node.right) {
-				var successor = minimum(node.right);
-				if (!node.parent) {
-					node.key = successor.key;
-					node.value = successor.value;
-				}
-				remove(successor, successor.key);
-			} else if (node.left) {
-				replaceInParent(node, node.left);
-			} else if (node.right) {
-				replaceInParent(node, node.right);
-			} else {
-				replaceInParent(node, null);
+			// Node to be deleted found
+			if (!node.left) {
+				return node.right;
+			} else if (!node.right) {
+				return node.left;
 			}
+			
+			// Node with two children: get the inorder successor
+			var successor = minimum(node.right);
+			node.key = successor.key;
+			node.value = successor.value;
+			node.right = remove(node.right, successor.key);
 		}
+		
+		return node;
 	}
 
 	btree.prototype.remove = function(key) {
-		remove(this.root, key);
+		this.root = remove(this.root, key);
 	}
 
 })();


### PR DESCRIPTION
## Description
Fixes critical bug in remove function where the root reference wasn't being updated after deletion.

## Changes
- Modified `remove` helper function to return the new node structure
- Updated `btree.prototype.remove` to assign result to `this.root`
- Simplified deletion logic for better maintainability
- Removed complex parent reference management

## Technical Details
- **Before**: `remove(this.root, key)` - didn't update root reference
- **After**: `this.root = remove(this.root, key)` - properly updates root
- Handles all deletion cases: leaf, single child, two children
- Maintains BST properties after deletion

## Testing
- Tested with simple string values
- Verified root reference updates correctly
- Confirmed tree structure remains valid

## Impact
- **Critical**: Fixes broken remove functionality
- No breaking changes to API
- Improves tree integrity after deletions